### PR TITLE
fix linter error in cyclic.hpp

### DIFF
--- a/reference_system/include/reference_system/nodes/rclcpp/cyclic.hpp
+++ b/reference_system/include/reference_system/nodes/rclcpp/cyclic.hpp
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef REFERENCE_SYSTEM__NODES__RCLCPP__REACTOR_HPP_
-#define REFERENCE_SYSTEM__NODES__RCLCPP__REACTOR_HPP_
+#ifndef REFERENCE_SYSTEM__NODES__RCLCPP__CYCLIC_HPP_
+#define REFERENCE_SYSTEM__NODES__RCLCPP__CYCLIC_HPP_
 #include <chrono>
 #include <string>
 #include <utility>
@@ -104,4 +104,4 @@ private:
 };
 }  // namespace rclcpp_system
 }  // namespace nodes
-#endif  // REFERENCE_SYSTEM__NODES__RCLCPP__REACTOR_HPP_
+#endif  // REFERENCE_SYSTEM__NODES__RCLCPP__CYCLIC_HPP_


### PR DESCRIPTION
Fixes the following
```
3: -- run_test.py: invoking following command in '/root/ws/src/reference-system/reference_system':
3:  - /opt/ros/galactic/bin/ament_cpplint --xunit-file /root/ws/build/reference_system/test_results/reference_system/cpplint.xunit.xml
3: /root/ws/src/reference-system/reference_system/include/reference_system/nodes/rclcpp/cyclic.hpp:14:  #ifndef header guard has wrong style, please use: REFERENCE_SYSTEM__NODES__RCLCPP__CYCLIC_HPP_  [build/header_guard] [5]
3: /root/ws/src/reference-system/reference_system/include/reference_system/nodes/rclcpp/cyclic.hpp:107:  #endif line should be "#endif  // REFERENCE_SYSTEM__NODES__RCLCPP__CYCLIC_HPP_"  [build/header_guard] [5]

```


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>