### PR TITLE
Reduce list of enabled tracepoints down to minimum

### DIFF
--- a/autoware_reference_system/test/generate_callback_traces.py
+++ b/autoware_reference_system/test/generate_callback_traces.py
@@ -22,7 +22,6 @@ import launch_testing
 import launch_testing.actions
 
 from tracetools_launch.action import Trace
-from tracetools_trace.tools.names import DEFAULT_CONTEXT
 from tracetools_trace.tools.names import DEFAULT_EVENTS_ROS
 
 # Generate traces for specified executables and RMWs
@@ -57,20 +56,8 @@ def generate_test_description():
 
     trace_action = Trace(
         session_name='callback_' + test_exe_name + '_' + str(RUNTIME) + 's',
-        events_ust=[
-            'lttng_ust_cyg_profile_fast:func_entry',
-            'lttng_ust_cyg_profile_fast:func_exit',
-            'lttng_ust_statedump:start',
-            'lttng_ust_statedump:end',
-            'lttng_ust_statedump:bin_info',
-            'lttng_ust_statedump:build_id'
-        ] + DEFAULT_EVENTS_ROS,
-        events_kernel=[
-            'sched_switch'
-        ],
-        context_names=[
-            'ip',
-        ] + DEFAULT_CONTEXT,
+        events_ust=DEFAULT_EVENTS_ROS,
+        events_kernel=[],
     )
 
     launch_description.add_action(envvar_rcutils_action)


### PR DESCRIPTION
Follow-up to #33

Since we are currently only using the tracing data to get callback durations (and not for CPU usage or memory consumption), we can reduce the list of enabled events down to just the ROS 2 tracepoints. Traces will be much smaller.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>