### PR TITLE
switch each executor to use default timing config

### DIFF
--- a/autoware_reference_system/README.md
+++ b/autoware_reference_system/README.md
@@ -143,9 +143,9 @@ Once the above steps are complete you sould be ready to configure the setup for 
 
 ## Configure Processing Time
 
-Many nodes in the reference system are actually performing some _psuedo work_ by finding prime numbers up until some _maximum value_.  Depending on the platform, this _maximum value_ will need to be changed so that these nodes do not take an absurd amount of time.  This _maximum value_ should be chosen on a platform-by-platform basis so that the total _run time_ of this work takes some desired amount.
+Many nodes in the reference system are actually performing some _psuedo work_ by finding prime numbers up until some _maximum value_.  Depending on the platform, this _maximum value_ will need to be changed so that these nodes do not take an absurd amount of time.  This _maximum value_ should be chosen on a platform-by-platform basis so that the total _run time_ of this work takes some desired length of time.
 
-In order to make finding this _maximum value_ a bit easier across many different platforms a simple **number_cruncher_benchmark** is provided that will loop over various _maximum values_ and spit out how long each one takes to run.  After running this executable on your platform you should have a good idea what _maximum value_ you should use in your [timing configuration](include/autoware_reference_system/system/timing/default.hpp) so that each node does some measurable work for some desired amount of time.
+In order to make finding this _maximum value_ a bit easier across many different platforms a simple [**number_cruncher_benchmark**](src/ros2/number_cruncher_benchmark.cpp) is provided that will loop over various _maximum values_ and spit out how long each one takes to run.  After running this executable on your platform you should have a good idea what _maximum value_ you should use in your [timing configuration](include/autoware_reference_system/system/timing/default.hpp) so that each node does some measurable work for some desired amount of time.
 
 Here is an example output of the `number_cruncher_benchmark` run on a typical development platform (Intel 9i7):
 
@@ -170,7 +170,7 @@ maximum_number     run time
      2097152       1149.79ms
 ```
 
-Run the above command on your system, select your desired `run_time` and place it in the [timing configuration file](include/autoware_reference_system/system/timing/default.hpp) for the desired nodes.
+Run the above command on your system, select your desired `run_time` and place the corresponding `maximum_number` in the [timing configuration file](include/autoware_reference_system/system/timing/default.hpp) for the desired nodes.
 
 ## Running the Tests
 

--- a/autoware_reference_system/README.md
+++ b/autoware_reference_system/README.md
@@ -136,8 +136,41 @@ Before running the tests there are a few prerequisites to complete:
    - _Note:_ make sure to clone `ros2_tracing` into **the same workspace as where you put the `reference-system`**, the tests will not properly run if they are not in the same directory.
 - install dependencies using the following command from the `colcon_ws` directory:
     - `rosdep install --from-paths src --ignore-src -y`
+- install `psrecord`, used to record CPU and memory usage
+    - `python3 -m pip install psrecord`
 
-Once the above steps are complete you sould be ready to run the tests and generate some results.
+Once the above steps are complete you sould be ready to configure the setup for your platform and run the tests to generate some results.
+
+## Configure Processing Time
+
+Many nodes in the reference system are actually performing some _psuedo work_ by finding prime numbers up until some _maximum value_.  Depending on the platform, this _maximum value_ will need to be changed so that these nodes do not take an absurd amount of time.  This _maximum value_ should be chosen on a platform-by-platform basis so that the total _run time_ of this work takes some desired amount.
+
+In order to make finding this _maximum value_ a bit easier across many different platforms a simple **number_cruncher_benchmark** is provided that will loop over various _maximum values_ and spit out how long each one takes to run.  After running this executable on your platform you should have a good idea what _maximum value_ you should use in your [timing configuration](include/autoware_reference_system/system/timing/default.hpp) so that each node does some measurable work for some desired amount of time.
+
+Here is an example output of the `number_cruncher_benchmark` run on a typical development platform (Intel 9i7):
+
+```
+ros2 run autoware_reference_system number_cruncher_benchmark 
+maximum_number     run time
+          64       0.001609ms
+         128       0.002896ms
+         256       0.006614ms
+         512       0.035036ms
+        1024       0.050957ms
+        2048       0.092732ms
+        4096       0.22837ms
+        8192       0.566779ms
+       16384       1.48837ms
+       32768       3.64588ms
+       65536       9.6687ms
+      131072       24.1154ms
+      262144       62.3475ms
+      524288       162.762ms
+     1048576       429.882ms
+     2097152       1149.79ms
+```
+
+Run the above command on your system, select your desired `run_time` and place it in the [timing configuration file](include/autoware_reference_system/system/timing/default.hpp) for the desired nodes.
 
 ## Running the Tests
 

--- a/autoware_reference_system/include/autoware_reference_system/system/timing/benchmark.hpp
+++ b/autoware_reference_system/include/autoware_reference_system/system/timing/benchmark.hpp
@@ -33,6 +33,11 @@ struct BenchmarkThroughput
   static constexpr time_t VISUALIZER = milliseconds(0);
   static constexpr time_t LANELET2MAP = milliseconds(0);
 
+  // the following values are used as the number_cruncher_limit
+  // to search for primes up to starting at 3
+  // for your platform, run the `number_cruncher_benchmark` executable
+  // to figure out what values to place here corresponding to the run_time
+  // you would like to run each node for
   // processing
   static constexpr uint64_t POINTS_TRANSFORMER_FRONT = 0;
   static constexpr uint64_t POINTS_TRANSFORMER_REAR = 0;
@@ -93,6 +98,11 @@ struct BenchmarkCPUUsage
   static constexpr time_t VISUALIZER = milliseconds(50);
   static constexpr time_t LANELET2MAP = milliseconds(50);
 
+  // the following values are used as the number_cruncher_limit
+  // to search for primes up to starting at 3
+  // for your platform, run the `number_cruncher_benchmark` executable
+  // to figure out what values to place here corresponding to the run_time
+  // you would like to run each node for
   // processing
   static constexpr uint64_t POINTS_TRANSFORMER_FRONT = 0;
   static constexpr uint64_t POINTS_TRANSFORMER_REAR = 0;

--- a/autoware_reference_system/include/autoware_reference_system/system/timing/default.hpp
+++ b/autoware_reference_system/include/autoware_reference_system/system/timing/default.hpp
@@ -28,31 +28,36 @@ struct Default
   // sensors
   static constexpr time_t FRONT_LIDAR_DRIVER = milliseconds(100);
   static constexpr time_t REAR_LIDAR_DRIVER = milliseconds(100);
-  static constexpr time_t POINT_CLOUD_MAP = milliseconds(100);
-  static constexpr time_t VISUALIZER = milliseconds(100);
+  static constexpr time_t POINT_CLOUD_MAP = milliseconds(120);
+  static constexpr time_t VISUALIZER = milliseconds(60);
   static constexpr time_t LANELET2MAP = milliseconds(100);
 
+  // the following values are used as the number_cruncher_limit
+  // to search for primes up to starting at 3
+  // for your platform, run the `number_cruncher_benchmark` executable
+  // to figure out what values to place here corresponding to the run_time
+  // you would like to run each node for
   // processing
-  static constexpr uint64_t POINTS_TRANSFORMER_FRONT = 10000000;
-  static constexpr uint64_t POINTS_TRANSFORMER_REAR = 10000000;
-  static constexpr uint64_t VOXEL_GRID_DOWNSAMPLER = 10000000;
-  static constexpr uint64_t POINT_CLOUD_MAP_LOADER = 10000000;
-  static constexpr uint64_t RAY_GROUND_FILTER = 10000000;
-  static constexpr uint64_t EUCLIDEAN_CLUSTER_DETECTOR = 10000000;
-  static constexpr uint64_t OBJECT_COLLISION_ESTIMATOR = 10000000;
-  static constexpr uint64_t MPC_CONTROLLER = 10000000;
-  static constexpr uint64_t PARKING_PLANNER = 10000000;
-  static constexpr uint64_t LANE_PLANNER = 10000000;
+  static constexpr uint64_t POINTS_TRANSFORMER_FRONT = 65536;
+  static constexpr uint64_t POINTS_TRANSFORMER_REAR = 65536;
+  static constexpr uint64_t VOXEL_GRID_DOWNSAMPLER = 65536;
+  static constexpr uint64_t POINT_CLOUD_MAP_LOADER = 65536;
+  static constexpr uint64_t RAY_GROUND_FILTER = 65536;
+  static constexpr uint64_t EUCLIDEAN_CLUSTER_DETECTOR = 65536;
+  static constexpr uint64_t OBJECT_COLLISION_ESTIMATOR = 65536;
+  static constexpr uint64_t MPC_CONTROLLER = 65536;
+  static constexpr uint64_t PARKING_PLANNER = 65536;
+  static constexpr uint64_t LANE_PLANNER = 65536;
 
   // fusion
-  static constexpr uint64_t POINT_CLOUD_FUSION = 10000000;
-  static constexpr uint64_t NDT_LOCALIZER = 10000000;
-  static constexpr uint64_t VEHICLE_INTERFACE = 10000000;
-  static constexpr uint64_t LANELET_2_GLOBAL_PLANNER = 10000000;
-  static constexpr uint64_t LANELET_2_MAP_LOADER = 10000000;
+  static constexpr uint64_t POINT_CLOUD_FUSION = 65536;
+  static constexpr uint64_t NDT_LOCALIZER = 65536;
+  static constexpr uint64_t VEHICLE_INTERFACE = 65536;
+  static constexpr uint64_t LANELET_2_GLOBAL_PLANNER = 65536;
+  static constexpr uint64_t LANELET_2_MAP_LOADER = 65536;
 
   // cyclic
-  static constexpr uint64_t BEHAVIOR_PLANNER = 10000000;
+  static constexpr uint64_t BEHAVIOR_PLANNER = 65536;
   static constexpr time_t BEHAVIOR_PLANNER_CYCLE = milliseconds(100);
 };
 

--- a/autoware_reference_system/src/ros2/executor/autoware_default_multithreaded.cpp
+++ b/autoware_reference_system/src/ros2/executor/autoware_default_multithreaded.cpp
@@ -24,9 +24,9 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  // using TimeConfig = nodes::timing::Default;
+  using TimeConfig = nodes::timing::Default;
   // uncomment for benchmarking
-  using TimeConfig = nodes::timing::BenchmarkCPUUsage;
+  // using TimeConfig = nodes::timing::BenchmarkCPUUsage;
   // set_benchmark_mode(true);
 
   auto nodes = create_autoware_nodes<RclcppSystem, TimeConfig>();

--- a/autoware_reference_system/src/ros2/executor/autoware_default_singlethreaded.cpp
+++ b/autoware_reference_system/src/ros2/executor/autoware_default_singlethreaded.cpp
@@ -24,9 +24,9 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  // using TimeConfig = nodes::timing::Default;
+  using TimeConfig = nodes::timing::Default;
   // uncomment for benchmarking
-  using TimeConfig = nodes::timing::BenchmarkCPUUsage;
+  // using TimeConfig = nodes::timing::BenchmarkCPUUsage;
   // set_benchmark_mode(true);
 
   auto nodes = create_autoware_nodes<RclcppSystem, TimeConfig>();

--- a/autoware_reference_system/src/ros2/executor/autoware_default_staticsinglethreaded.cpp
+++ b/autoware_reference_system/src/ros2/executor/autoware_default_staticsinglethreaded.cpp
@@ -24,9 +24,9 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  // using TimeConfig = nodes::timing::Default;
+  using TimeConfig = nodes::timing::Default;
   // uncomment for benchmarking
-  using TimeConfig = nodes::timing::BenchmarkCPUUsage;
+  // using TimeConfig = nodes::timing::BenchmarkCPUUsage;
   // set_benchmark_mode(true);
 
   auto nodes = create_autoware_nodes<RclcppSystem, TimeConfig>();

--- a/autoware_reference_system/test/generate_reports.py
+++ b/autoware_reference_system/test/generate_reports.py
@@ -81,7 +81,7 @@ def checkPath(p):
 def initCallbackTraceData():
     events = load_file(path)
     handler = Ros2Handler.process(events)
-    handler.data.print_data()
+    # handler.data.print_data()
 
     global ros2_data_model
     ros2_data_model = Ros2DataModelUtil(handler.data)

--- a/autoware_reference_system/test/generate_summary_reports.py
+++ b/autoware_reference_system/test/generate_summary_reports.py
@@ -79,7 +79,7 @@ def checkPath(p):
 def initCallbackTraceData():
     events = load_file(path)
     handler = Ros2Handler.process(events)
-    handler.data.print_data()
+    # handler.data.print_data()
 
     global ros2_data_model
     ros2_data_model = Ros2DataModelUtil(handler.data)


### PR DESCRIPTION
Signed-off-by: Evan Flynn <evan.flynn@apex.ai>

the previous `benchmark` timings resulted in no processing time being done for any of the nodes. for now lets switch to the default timings so when tests are ran _some work_ is actually done in each node.

most likely we will have to fine-tune the timings on each platform to get the desired results.