### PR TITLE
Add test_depend on ament_lint_{auto,common} for reference_interfaces

### DIFF
--- a/reference_interfaces/package.xml
+++ b/reference_interfaces/package.xml
@@ -12,6 +12,8 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
Otherwise `reference_interfaces` fails to build from source, saying it cannot find `ament_cmake_cppcheck`. It's required by `rosidl_generator_c`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>