### PR TITLE
Separate oute docs jobs, fix mike deploy command

### DIFF
--- a/.github/workflows/build_deploy_docs.yml
+++ b/.github/workflows/build_deploy_docs.yml
@@ -1,0 +1,29 @@
+name: Generate documentation site
+on:
+  push:
+    branches: 
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-deply-docs:
+    runs-on: ubuntu-latest
+    # Only run if doxybook was generated
+    needs: generate-doxybook
+    steps:
+      - name: Download Doxybook2 markdown
+        uses: actions/download-artifact@v3
+        with:
+          name: doxybook_markdown
+      - name: build mkdocs site
+        run: |
+          cd ros2_ws/src/reference_system/
+          # ensure gh-pages git history is fetched
+          git fetch origin gh-pages --depth=1
+          cd docs
+          apt-get update -y
+          # install mkdocs dependencies
+          pip3 install mkdocs mkdocs-material mike
+          # since this workflow is triggered by a push to main, set to `latest` alias
+          mike deploy --push --update-aliases main latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,24 +1,18 @@
-# This is a basic workflow to help you get started with Actions
+name: Build reference_system packages
 
-name: CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
-
+    branches:
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: [ubuntu-latest]
+  build-and-test:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,4 @@
-name: Build reference_system packages
+name: Build and test
 
 on:
   push:

--- a/.github/workflows/generate_doxybook.yml
+++ b/.github/workflows/generate_doxybook.yml
@@ -1,0 +1,32 @@
+name: Generate Doxybook2
+
+on:
+  push:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  generate-doxybook2:
+    runs-on: ubuntu-latest
+    needs: generate_doxygen
+    steps:
+      - name: Download Doxygen XML
+        uses: actions/download-artifact@v3
+        with:
+          name: doxygen_xml
+      - name: Build Doxybook2
+        run: |
+          mkdir ros2_ws/src/reference_system/docs/markdown
+          wget https://github.com/matusnovak/doxybook2/releases/download/v1.4.0/doxybook2-linux-amd64-v1.4.0.zip
+          apt-get install unzip
+          unzip doxybook2-linux-amd64-v1.4.0.zip
+          ./bin/doxybook2 --input ros2_ws/src/reference_system/docs/xml \
+            --output ros2_ws/src/reference_system/docs/markdown \
+            --config ros2_ws/src/reference_system/docs/doxybook2_config.json
+      - name: Upload Doxybook2 markdown
+        uses: actions/upload-artifact@v3
+        with:
+          name: doxybook_markdown
+          path: 'ros2_ws/src/reference_system/docs/markdown'
+          retention-days: 30

--- a/.github/workflows/generate_doxygen.yml
+++ b/.github/workflows/generate_doxygen.yml
@@ -1,4 +1,4 @@
-name: Generate Documentation
+name: Generate Doxygen XML 
 
 # Controls when the workflow will run
 on:
@@ -12,41 +12,30 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  generate_docs:
+  generate-doxygen:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    # Only build docs if build / test jobs were successful
+    needs: build_and_test
     container:
       image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: setup workspace
+      - name: Setup workspace
         # TODO(flynneva): make this a variable and use it at every step
         run: mkdir -p ros2_ws/src/reference_system
       - name: checkout
         uses: actions/checkout@v2
         with:
           path: ros2_ws/src/reference_system
-      - name: build doxygen
+      - name: Run Doxygen on source
         uses: mattnotmitt/doxygen-action@v1
         with:
           working-directory: 'ros2_ws/src/reference_system'
           doxyfile-path: '.doxygen/Doxyfile'
-      - name: build doxybook2
-        run: |
-          mkdir ros2_ws/src/reference_system/docs/markdown
-          wget https://github.com/matusnovak/doxybook2/releases/download/v1.4.0/doxybook2-linux-amd64-v1.4.0.zip
-          apt-get install unzip
-          unzip doxybook2-linux-amd64-v1.4.0.zip
-          ./bin/doxybook2 --input ros2_ws/src/reference_system/docs/xml \
-            --output ros2_ws/src/reference_system/docs/markdown \
-            --config ros2_ws/src/reference_system/docs/doxybook2_config.json
-      - name: build mkdocs site
-        run: |
-          cd ros2_ws/src/reference_system/
-          # ensure gh-pages git history is fetched
-          git fetch origin gh-pages --depth=1
-          cd docs
-          apt-get update -y
-          # install mkdocs dependencies
-          pip3 install mkdocs mkdocs-material mike
-          mike deploy main latest
+      - name: Upload Doxygen XML
+        uses: actions/upload-artifact@v3
+        with:
+          name: doxygen_xml
+          path: 'ros2_ws/src/reference_system/docs/xml'
+          retention-days: 30

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -1,0 +1,60 @@
+name: Run reference_system benchmark
+
+on:
+  push:
+    tags:
+      - '**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution:
+          - foxy
+          - galactic
+          - rolling
+        include:
+          # Foxy Fitzroy (June 2020 - May 2023)
+          - ros_distribution: foxy
+            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+          # Galactic Geochelone (May 2021 - November 2022)
+          - ros_distribution: galactic
+            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
+          # Rolling Ridley  (June 2020 - Present)
+          - ros_distribution: rolling
+            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-ros-base-latest
+    container:
+      image: ${{ matrix.docker_image }}
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: setup workspace
+        run: mkdir -p ros2_ws/src
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          path: ros2_ws/src
+      - name: build and test
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: autoware_reference_system reference_system reference_interfaces
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ""
+          colcon-defaults: |
+            {
+              "build": {
+                "cmake-args": [
+                  "-DRUN_BENCHMARK=ON",
+                  "-DALL_RMWS=ON"
+                ]
+              }
+            }
+      - name: Upload Benchmark Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark_reports
+          path: '~/.ros/benchmark_autoware_reference_system'
+          retention-days: 60

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 docs/xml
 docs/markdown
 docs/site
+
+# ignore the doxybook2 stuff if installed
+doxybook2**
+bin
+include
+lib

--- a/autoware_reference_system/CMakeLists.txt
+++ b/autoware_reference_system/CMakeLists.txt
@@ -84,7 +84,8 @@ if(${BUILD_TESTING})
       5
       # 10
       # 30
-      # 60
+      60
+      120
     )
 
     # Add more trace types here

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,7 +7,6 @@ plugins:
 extra:
   version:
     provider: mike
-    default: stable
 nav:
   - Home: Pages/md_README
   - Reports: Reports

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: Reference System Documentation
+site_url: https://ros-realtime.github.io/reference-system/
+site_author: Evan Flynn
+repo_url: https://github.com/ros-realtime/reference-system.git
 docs_dir: markdown
 theme:
   name: 'material'


### PR DESCRIPTION
Separates out the doc  workflow to specific jobs to hopefully setup future work to trigger the docs on tags as well.

Signed-off-by: Evan Flynn <evanflynn.msu@gmail.com>