### PR TITLE
Use github default download artifact action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -77,12 +77,10 @@ jobs:
         with:
           path: ${{ env.WORKSPACE_PATH }}
       - name: Download API Reference
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.DOXYBOOK_ARTIFACT }}
           path: ${{ env.WORKSPACE_PATH }}/docs/api-reference
-          workflow: build_docs.yml
-          check_artifacts: true
       - name: Build mkdocs site
         run: |
           cd ${{ env.WORKSPACE_PATH }}
@@ -173,43 +171,34 @@ jobs:
         with:
           path: ${{ env.WORKSPACE_PATH }}
       - name: Download API reference
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.DOXYBOOK_ARTIFACT }}
           path: ${{ env.WORKSPACE_PATH }}/docs/api-reference
-          workflow: build_docs.yml
       - name: Download Foxy reports
         continue-on-error: true  # Still publish docs even if reports are not available
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: autoware_benchmark_reports_foxy
           path: ${{ env.WORKSPACE_PATH }}/docs/reports/foxy
-          workflow: build_docs.yml
-          check_artifacts: true
       - name: Download Galactic reports
         continue-on-error: true  # Still publish docs even if reports are not available
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: autoware_benchmark_reports_galactic
           path: ${{ env.WORKSPACE_PATH }}/docs/reports/galactic
-          workflow: build_docs.yml
-          check_artifacts: true
       - name: Download Humble reports
         continue-on-error: true  # Still publish docs even if reports are not available
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: autoware_benchmark_reports_humble
           path: ${{ env.WORKSPACE_PATH }}/docs/reports/humble
-          workflow: build_docs.yml
-          check_artifacts: true
       - name: Download Rolling reports
         continue-on-error: true  # Still publish docs even if reports are not available
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: autoware_benchmark_reports_rolling
           path: ${{ env.WORKSPACE_PATH }}/docs/reports/rolling
-          workflow: build_docs.yml
-          check_artifacts: true
       - name: Deploy mkdocs site
         shell: bash
         run: |


### PR DESCRIPTION
It looks like the `dawidd6/action-download-artifact` action does not do what I think it does, switch to the default download artifact action from github.

Signed-off-by: Evan Flynn <evan.flynn@apex.ai>