### PR TITLE
Add Iron to CI, remove EoL distros, bump version for docs

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,20 +28,16 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - foxy
-          - galactic
           - humble
+          - iron
           - rolling
         include:
-          # Foxy Fitzroy (June 2020 - May 2023)
-          - ros_distribution: foxy
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
-          # Galactic Geochelone (May 2021 - November 2022)
-          - ros_distribution: galactic
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
           # Humble Hawksbill (May 2022 - May 2027)
           - ros_distribution: humble
             docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+          # Iron Irwini (May 2023 - November 2024)
+          - ros_distribution: iron
+            docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
           # Rolling Ridley  (June 2020 - Present)
           - ros_distribution: rolling
             docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
@@ -56,7 +52,7 @@ jobs:
         with:
           path: ${{ env.CLONE_PATH }}
       - name: Build and test
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: autoware_reference_system reference_system reference_interfaces
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/autoware_reference_system/CHANGELOG.rst
+++ b/autoware_reference_system/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package autoware_reference_system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+v1.1.0
+------
+* Add Iron ROS 2 distribution
+* Remove EoL distributions Foxy and Galactic
+* Remove legacy hack for rosidl_geneartor_py
+
 v1.0.0
 -----------
 * Add first changelog

--- a/autoware_reference_system/package.xml
+++ b/autoware_reference_system/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_reference_system</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Autoware Reference System for the ROScon workshop</description>
   <maintainer email="evan.flynn@apex.ai">Evan Flynn</maintainer>
   <license>Apache License 2.0</license>

--- a/reference_interfaces/CHANGELOG.rst
+++ b/reference_interfaces/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package reference_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+v1.1.0
+------
+* Add Iron ROS 2 distribution
+* Remove EoL distributions Foxy and Galactic
+* Remove legacy hack for rosidl_geneartor_py
+
 v1.0.0
 -----------
 * Add first changelog

--- a/reference_interfaces/CMakeLists.txt
+++ b/reference_interfaces/CMakeLists.txt
@@ -32,32 +32,3 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 
 ament_auto_package()
-
-# remove the below lines if fix to #143 is backported to older ROS distros
-# fix rosidl_generator_py bug #143
-# https://github.com/ros2/rosidl_python/issues/143
-set(GENERATED_FILE "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py/${PROJECT_NAME}/msg/_transmission_stats.py")
-
-set(DISTROS_WITH_FIX
-  "humble")
-list(FIND DISTROS_WITH_FIX $ENV{ROS_DISTRO} DISTRO_ALREADY_FIXED)
-
-if (${DISTRO_ALREADY_FIXED} MATCHES -1)
-  message(STATUS "checking generated file: ${GENERATED_FILE}")
-
-  set(DISTROS_WITH_RENAMED_TARGET "rolling")
-  list(FIND DISTROS_WITH_RENAMED_TARGET $ENV{ROS_DISTRO} TARGET_RENAMED)
-
-  if (${TARGET_RENAMED} MATCHES -1)
-    set(TARGET_NAME ${PROJECT_NAME}__python)
-  else()
-    set(TARGET_NAME ${PROJECT_NAME}__rosidl_generator_py)
-  endif()
-
-  add_custom_command(
-    TARGET ${TARGET_NAME}
-    POST_BUILD
-    COMMAND sed -i "s/all(val >= 0 and val) < 256/all(ord(val) >= 0 and ord(val) < 256/" ${GENERATED_FILE}
-    COMMENT "Check generated IDL files for extra parenthesis..."
-    VERBATIM)
-endif()

--- a/reference_interfaces/package.xml
+++ b/reference_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>reference_interfaces</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Reference system for the ROScon workshop</description>
   <maintainer email="christian.eltzschig@apex.ai">Christian Eltzschig</maintainer>
   <license>Apache License 2.0</license>

--- a/reference_system/CHANGELOG.rst
+++ b/reference_system/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package reference_system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+v1.1.0
+------
+* Add Iron ROS 2 distribution
+* Remove EoL distributions Foxy and Galactic
+* Remove legacy hack for rosidl_geneartor_py
+
 v1.0.0
 -----------
 * Add first changelog

--- a/reference_system/package.xml
+++ b/reference_system/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>reference_system</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Reference system for the ROScon workshop</description>
   <maintainer email="evan.flynn@apex.ai">Evan Flynn</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
- add Iron to CI
- remove Foxy and Galactic EoL distros
- remove hack around [rosidl_generator_py bug](https://github.com/ros2/rosidl_python/issues/143)
- bump version to 1.1.0 so to not overwrite old docs reports