### PR TITLE
Update distros to run benchmarks on

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -104,20 +104,16 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - foxy
-          - galactic
           - humble
+          - iron
           - rolling
         include:
-          # Foxy Fitzroy (June 2020 - May 2023)
-          - ros_distribution: foxy
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
-          # Galactic Geochelone (May 2021 - November 2022)
-          - ros_distribution: galactic
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
           # Humble Hawksbill (May 2022 - May 2027)
           - ros_distribution: humble
             docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+          # Iron Irwini (May 2023 - November 2024)
+          - ros_distribution: iron
+            docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
           # Rolling Ridley  (June 2020 - Present)
           - ros_distribution: rolling
             docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest


### PR DESCRIPTION
Forgot to include this in #143 

This updates the ROS 2 distros that are included in the CI benchmark tests included in the documentation